### PR TITLE
Add commands to NotQuests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     compileOnly 'com.destroystokyo.paper:paper-api:1.15.2-R0.1-SNAPSHOT'
     compileOnly 'net.whimxiqal.journey:core-api:1.1-SNAPSHOT'
     compileOnly 'net.whimxiqal.journey:bukkit-api:1.1-SNAPSHOT'

--- a/src/main/java/net/whimxiqal/journey/integration/notquests/StartQuestListener.java
+++ b/src/main/java/net/whimxiqal/journey/integration/notquests/StartQuestListener.java
@@ -48,7 +48,7 @@ public class StartQuestListener implements Listener {
       return;  // there was no location associated with this objective
     }
 
-    if (!firstObjective.getConfig().getBoolean(firstObjective.getInitialConfigPath() + ".journey", false)) {
+    if (!firstObjective.getConfig().getBoolean(firstObjective.getInitialConfigPath() + ".useJourney", false)) {
       return;  // config doesn't specify to use journey
     }
 


### PR DESCRIPTION
NotQuests has many commands to edit quests and objectives. Objectives may have locations associated with them, so in addition to setting it in the config, you can also now set `useJourney` to `true` *using NotQuest commands* for any objectives with a set location